### PR TITLE
Revert "Bump rack from 2.0.6 to 2.0.8"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     public_suffix (3.0.3)
-    rack (2.0.8)
+    rack (2.0.6)
     rack-protection (2.0.4)
       rack
     sawyer (0.8.1)


### PR DESCRIPTION
Reverts github-developer/using-the-github-api-in-your-app#14