### PR TITLE
docs: update link to Bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To learn how to set up a template GitHub App, follow the "[Setting up your devel
 
 ## Install
 
-To run the code, make sure you have [Bundler](http://gembundler.com/) installed; then enter `bundle install` on the command line.
+To run the code, make sure you have [Bundler](https://bundler.io/) installed; then enter `bundle install` on the command line.
 
 ## Set environment variables
 


### PR DESCRIPTION
This PR updates the link to Bundler from gembundler.com (a Wordpress site) to bundler.io.

cc: @rachmari for review based on the suggested reviewers :v: